### PR TITLE
Update main.go

### DIFF
--- a/main.go
+++ b/main.go
@@ -102,7 +102,7 @@ func createRequestBodyFromConfigs(configs ConfigsModel) ([]byte, error) {
 }
 
 func createRequest(appSlug string, body []byte) (*http.Request, error) {
-	requestURL := fmt.Sprintf("https://www.bitrise.io/app/%s/build/start.json", appSlug)
+	requestURL := fmt.Sprintf("https://app.bitrise.io/app/%s/build/start.json", appSlug)
 	request, err := http.NewRequest("POST", requestURL, bytes.NewBuffer(body))
 	if request != nil {
 		request.Header.Add("Content-Type", "application/json")


### PR DESCRIPTION
`www` subdomain deprecated in favor of `app`
https://discuss.bitrise.io/t/deprecation-of-build-trigger-api-on-www-subdomain-use-app-subdomain-or-the-public-api-instead/4721